### PR TITLE
fix: VP9 HWAccel

### DIFF
--- a/patches/ffmpeg-fix-vp9-hwaccel.patch
+++ b/patches/ffmpeg-fix-vp9-hwaccel.patch
@@ -1,11 +1,9 @@
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-old mode 100644
-new mode 100755
-index 8775d15a4f..3154385331
+index e593ad1..f074ac8 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -893,6 +893,7 @@ extern const FFCodec ff_vp9_mediacodec_decoder;
- extern const FFCodec ff_vp9_mediacodec_encoder;
+@@ -884,6 +884,7 @@ extern const FFCodec ff_vp9_cuvid_decoder;
+ extern const FFCodec ff_vp9_mediacodec_decoder;
  extern const FFCodec ff_vp9_qsv_decoder;
  extern const FFCodec ff_vp9_vaapi_encoder;
 +extern const FFCodec ff_vp9_videotoolbox_decoder;
@@ -13,12 +11,10 @@ index 8775d15a4f..3154385331
  
  // null codecs
 diff --git a/libavcodec/vp9.c b/libavcodec/vp9.c
-old mode 100644
-new mode 100755
-index 89f7549ef0..cc873b7620
+index 7c0a246..2abd3d3 100644
 --- a/libavcodec/vp9.c
 +++ b/libavcodec/vp9.c
-@@ -1917,9 +1917,38 @@ const FFCodec ff_vp9_decoder = {
+@@ -1906,6 +1906,35 @@ const FFCodec ff_vp9_decoder = {
  #if CONFIG_VP9_VDPAU_HWACCEL
                                 HWACCEL_VDPAU(vp9),
  #endif
@@ -27,34 +23,30 @@ index 89f7549ef0..cc873b7620
 +};
 +
 +const FFCodec ff_vp9_videotoolbox_decoder = {
-+        .p.name                = "vp9_videotoolbox",
-+        CODEC_LONG_NAME("VideoToolbox Google VP9"),
-+        .p.type                = AVMEDIA_TYPE_VIDEO,
-+        .p.id                  = AV_CODEC_ID_VP9,
-+        .priv_data_size        = sizeof(VP9Context),
-+        .init                  = vp9_decode_init,
-+        .close                 = vp9_decode_free,
-+        FF_CODEC_DECODE_CB(vp9_decode_frame),
-+        .p.capabilities        = AV_CODEC_CAP_DR1 | AV_CODEC_CAP_FRAME_THREADS | AV_CODEC_CAP_SLICE_THREADS,
-+        .caps_internal         = FF_CODEC_CAP_INIT_CLEANUP |
-+                                 FF_CODEC_CAP_SLICE_THREAD_HAS_MF |
-+                                 FF_CODEC_CAP_ALLOCATE_PROGRESS,
-+        .flush                 = vp9_decode_flush,
-+        UPDATE_THREAD_CONTEXT(vp9_decode_update_thread_context),
-+        .p.profiles            = NULL_IF_CONFIG_SMALL(ff_vp9_profiles),
++    .p.name                = "vp9_videotoolbox",
++    CODEC_LONG_NAME("VideoToolbox Google VP9"),
++    .p.type                = AVMEDIA_TYPE_VIDEO,
++    .p.id                  = AV_CODEC_ID_VP9,
++    .priv_data_size        = sizeof(VP9Context),
++    .init                  = vp9_decode_init,
++    .close                 = vp9_decode_free,
++    FF_CODEC_DECODE_CB(vp9_decode_frame),
++    .p.capabilities        = AV_CODEC_CAP_DR1 | AV_CODEC_CAP_FRAME_THREADS | AV_CODEC_CAP_SLICE_THREADS,
++    .caps_internal         = FF_CODEC_CAP_INIT_CLEANUP |
++                                FF_CODEC_CAP_SLICE_THREAD_HAS_MF |
++                                FF_CODEC_CAP_ALLOCATE_PROGRESS,
++    .flush                 = vp9_decode_flush,
++    UPDATE_THREAD_CONTEXT(vp9_decode_update_thread_context),
++    .p.profiles            = NULL_IF_CONFIG_SMALL(ff_vp9_profiles),
 +#if ARCH_X86_64
-+        /* Video Toolbox requires VP9 invisible (alt-ref) frames be merged into VP9 superframes when running on Intel
-+         * based Macs. Violation of this requirement will cause Video Toolbox to hang due to defective error handing
-+         * in VTDecompressionSessionDecodeFrame. See FFmpeg ticket #9599. */
-+        .bsfs                  = "vp9_superframe",
++    /* @low-batt: Video Toolbox requires VP9 invisible (alt-ref) frames be merged into VP9 superframes when running on Intel
++     * based Macs. Violation of this requirement will cause Video Toolbox to hang due to defective error handing
++     * in VTDecompressionSessionDecodeFrame. See FFmpeg ticket #9599. */
++    .bsfs                  = "vp9_superframe",
 +#else
-+        .bsfs                  = "vp9_superframe_split",
++    .bsfs                  = "vp9_superframe_split",
 +#endif
-+        .hw_configs            = (const AVCodecHWConfigInternal *const []) {
++    .hw_configs            = (const AVCodecHWConfigInternal *const []) {
  #if CONFIG_VP9_VIDEOTOOLBOX_HWACCEL
                                 HWACCEL_VIDEOTOOLBOX(vp9),
  #endif
-                                NULL
--                           },
-+        },
- };

--- a/patches/ffmpeg-fix-vp9-hwaccel.patch
+++ b/patches/ffmpeg-fix-vp9-hwaccel.patch
@@ -1,0 +1,60 @@
+diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
+old mode 100644
+new mode 100755
+index 8775d15a4f..3154385331
+--- a/libavcodec/allcodecs.c
++++ b/libavcodec/allcodecs.c
+@@ -893,6 +893,7 @@ extern const FFCodec ff_vp9_mediacodec_decoder;
+ extern const FFCodec ff_vp9_mediacodec_encoder;
+ extern const FFCodec ff_vp9_qsv_decoder;
+ extern const FFCodec ff_vp9_vaapi_encoder;
++extern const FFCodec ff_vp9_videotoolbox_decoder;
+ extern const FFCodec ff_vp9_qsv_encoder;
+ 
+ // null codecs
+diff --git a/libavcodec/vp9.c b/libavcodec/vp9.c
+old mode 100644
+new mode 100755
+index 89f7549ef0..cc873b7620
+--- a/libavcodec/vp9.c
++++ b/libavcodec/vp9.c
+@@ -1917,9 +1917,38 @@ const FFCodec ff_vp9_decoder = {
+ #if CONFIG_VP9_VDPAU_HWACCEL
+                                HWACCEL_VDPAU(vp9),
+ #endif
++                               NULL
++                           },
++};
++
++const FFCodec ff_vp9_videotoolbox_decoder = {
++        .p.name                = "vp9_videotoolbox",
++        CODEC_LONG_NAME("VideoToolbox Google VP9"),
++        .p.type                = AVMEDIA_TYPE_VIDEO,
++        .p.id                  = AV_CODEC_ID_VP9,
++        .priv_data_size        = sizeof(VP9Context),
++        .init                  = vp9_decode_init,
++        .close                 = vp9_decode_free,
++        FF_CODEC_DECODE_CB(vp9_decode_frame),
++        .p.capabilities        = AV_CODEC_CAP_DR1 | AV_CODEC_CAP_FRAME_THREADS | AV_CODEC_CAP_SLICE_THREADS,
++        .caps_internal         = FF_CODEC_CAP_INIT_CLEANUP |
++                                 FF_CODEC_CAP_SLICE_THREAD_HAS_MF |
++                                 FF_CODEC_CAP_ALLOCATE_PROGRESS,
++        .flush                 = vp9_decode_flush,
++        UPDATE_THREAD_CONTEXT(vp9_decode_update_thread_context),
++        .p.profiles            = NULL_IF_CONFIG_SMALL(ff_vp9_profiles),
++#if ARCH_X86_64
++        /* Video Toolbox requires VP9 invisible (alt-ref) frames be merged into VP9 superframes when running on Intel
++         * based Macs. Violation of this requirement will cause Video Toolbox to hang due to defective error handing
++         * in VTDecompressionSessionDecodeFrame. See FFmpeg ticket #9599. */
++        .bsfs                  = "vp9_superframe",
++#else
++        .bsfs                  = "vp9_superframe_split",
++#endif
++        .hw_configs            = (const AVCodecHWConfigInternal *const []) {
+ #if CONFIG_VP9_VIDEOTOOLBOX_HWACCEL
+                                HWACCEL_VIDEOTOOLBOX(vp9),
+ #endif
+                                NULL
+-                           },
++        },
+ };

--- a/scripts/ffmpeg/build.sh
+++ b/scripts/ffmpeg/build.sh
@@ -5,6 +5,7 @@ set -u # treat unset variables as an error
 
 cd ${SRC_DIR}
 
+patch -p1 <${PROJECT_DIR}/patches/ffmpeg-fix-vp9-hwaccel.patch
 patch -p1 <${PROJECT_DIR}/patches/ffmpeg-fix-ios-hdr-texture.patch
 patch -p1 <${PROJECT_DIR}/patches/ffmpeg-fix-dash-base-url-escape.patch
 


### PR DESCRIPTION
Adds a VP9 Video Toolbox decoder to `ffmpeg` to fix freezes on macOS Intel based hardware.

Refs:
- https://trac.ffmpeg.org/ticket/9599
- https://trac.ffmpeg.org/attachment/ticket/9599/ticket-9599.patch

Thanks:
- @23doors for bringing this into sight
- @low-batt for its patch uploaded to FFmpeg tracker