### PR TITLE
fix: --enable-decoder=movtext

### DIFF
--- a/scripts/ffmpeg/meson.build
+++ b/scripts/ffmpeg/meson.build
@@ -206,7 +206,7 @@ video_default_options = [
     '--enable-decoder=text',
     '--enable-decoder=vplayer',
     '--enable-decoder=webvtt',
-    '--enable-decoder=mov_text',
+    '--enable-decoder=movtext',
 
     # parsers
     '--enable-parser=h263',


### PR DESCRIPTION
It's actually "movtext" & not "mov_text" as I looked in FFmpeg's `./configure --list-decoders`.

The same appears to work on Android now.