### PR TITLE
feat: add tvOS and tvOS Simulator build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Heavily inspired by [Homebrew](https://github.com/Homebrew/brew) and
 - Nix: [nixos.org/download/#nix-install-macos](https://nixos.org/download/#nix-install-macos)
 - Xcode: [./nix/overlays/xcode.md#how-to-store-xcode-and-prevent-to-be-garbage-collected](./nix/overlays/xcode.md#how-to-store-xcode-and-prevent-to-be-garbage-collected)
 
-## Build
+## Build 
 
 ```shell
 $ echo \"v0.0.1\" > nix/utils/default/version.nix

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ with commercial use for playback, and GPL use for encoding.
 Heavily inspired by [Homebrew](https://github.com/Homebrew/brew) and
 [IINA](https://github.com/iina/iina).
 
-## Setup 
+## Setup
 
 - Nix: [nixos.org/download/#nix-install-macos](https://nixos.org/download/#nix-install-macos)
 - Xcode: [./nix/overlays/xcode.md#how-to-store-xcode-and-prevent-to-be-garbage-collected](./nix/overlays/xcode.md#how-to-store-xcode-and-prevent-to-be-garbage-collected)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Heavily inspired by [Homebrew](https://github.com/Homebrew/brew) and
 - Nix: [nixos.org/download/#nix-install-macos](https://nixos.org/download/#nix-install-macos)
 - Xcode: [./nix/overlays/xcode.md#how-to-store-xcode-and-prevent-to-be-garbage-collected](./nix/overlays/xcode.md#how-to-store-xcode-and-prevent-to-be-garbage-collected)
 
-## Build 
+## Build
 
 ```shell
 $ echo \"v0.0.1\" > nix/utils/default/version.nix

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ with commercial use for playback, and GPL use for encoding.
 Heavily inspired by [Homebrew](https://github.com/Homebrew/brew) and
 [IINA](https://github.com/iina/iina).
 
-## Setup
+## Setup 
 
 - Nix: [nixos.org/download/#nix-install-macos](https://nixos.org/download/#nix-install-macos)
 - Xcode: [./nix/overlays/xcode.md#how-to-store-xcode-and-prevent-to-be-garbage-collected](./nix/overlays/xcode.md#how-to-store-xcode-and-prevent-to-be-garbage-collected)

--- a/README.md
+++ b/README.md
@@ -147,6 +147,23 @@ Inclusion:
       <td><code>12.0</code></td>
       <td>Required by <code>xcodebuild -create-xcframework</code></td>
     </tr>
+    <tr>
+      <td><strong>tvOS</strong></td>
+      <td>arm64</td>
+      <td><code>12.0</code></td>
+      <td>OpenGL ES deprecated since tvOS 12.0 but still linkable</td>
+    </tr>
+    <tr>
+      <td rowspan="2"><strong>tvOS Simulator</strong></td>
+      <td>amd64</td>
+      <td><code>12.0</code></td>
+      <td>Matches device baseline</td>
+    </tr>
+    <tr>
+      <td>arm64</td>
+      <td><code>12.0</code></td>
+      <td>Required by <code>xcodebuild -create-xcframework</code></td>
+    </tr>
   </tbody>
 </table>
 

--- a/cross-files/tvos-arm64.ini
+++ b/cross-files/tvos-arm64.ini
@@ -1,0 +1,41 @@
+[constants]
+arch          = 'arm64'
+platform_name = 'AppleTVOS'
+min_version   = '-mtvos-version-min=12.0'
+silence       = ['-DGLES_SILENCE_DEPRECATION', '-DCOREVIDEO_SILENCE_GL_DEPRECATION', '-U_LIBCPP_ENABLE_ASSERTIONS']
+xcode         = '/Applications/Xcode.app'
+xctoolchain   = xcode + '/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin'
+xcplatform    = xcode + '/Contents/Developer/Platforms/' + platform_name + '.platform/Developer/SDKs/' + platform_name + '.sdk'
+
+[host_machine]
+system     = 'darwin'
+cpu_family = 'aarch64'
+cpu        = 'arm64'
+endian     = 'little'
+
+[binaries]
+c          = xctoolchain + '/clang'
+cpp        = xctoolchain + '/clang++'
+objc       = xctoolchain + '/clang'
+objcpp     = xctoolchain + '/clang++'
+nm         = xctoolchain + '/nm'
+ar         = xctoolchain + '/ar'
+strip      = xctoolchain + '/strip'
+lipo       = xctoolchain + '/lipo'
+strings    = xctoolchain + '/strings'
+ranlib     = xctoolchain + '/ranlib'
+pkg-config = 'pkg-config'
+
+[built-in options]
+c_args           = ['-arch', arch, '-isysroot', xcplatform, min_version] + silence
+cpp_args         = ['-arch', arch, '-isysroot', xcplatform, min_version, '-stdlib=libc++'] + silence
+objc_args        = ['-arch', arch, '-isysroot', xcplatform, min_version] + silence
+objcpp_args      = ['-arch', arch, '-isysroot', xcplatform, min_version, '-stdlib=libc++'] + silence
+c_link_args      = ['-arch', arch, '-isysroot', xcplatform, min_version]
+cpp_link_args    = ['-arch', arch, '-isysroot', xcplatform, min_version]
+objc_link_args   = ['-arch', arch, '-isysroot', xcplatform, min_version]
+objcpp_link_args = ['-arch', arch, '-isysroot', xcplatform, min_version]
+
+[properties]
+cmake_osx_sysroot = xcplatform
+cross_prefix      = xctoolchain

--- a/cross-files/tvossimulator-amd64.ini
+++ b/cross-files/tvossimulator-amd64.ini
@@ -1,0 +1,41 @@
+[constants]
+arch          = 'x86_64'
+platform_name = 'AppleTVSimulator'
+min_version   = '-mtvos-version-min=12.0'
+silence       = ['-DGLES_SILENCE_DEPRECATION', '-DCOREVIDEO_SILENCE_GL_DEPRECATION', '-U_LIBCPP_ENABLE_ASSERTIONS']
+xcode         = '/Applications/Xcode.app'
+xctoolchain   = xcode + '/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin'
+xcplatform    = xcode + '/Contents/Developer/Platforms/' + platform_name + '.platform/Developer/SDKs/' + platform_name + '.sdk'
+
+[host_machine]
+system     = 'darwin'
+cpu_family = 'x86_64'
+cpu        = 'amd64'
+endian     = 'little'
+
+[binaries]
+c          = xctoolchain + '/clang'
+cpp        = xctoolchain + '/clang++'
+objc       = xctoolchain + '/clang'
+objcpp     = xctoolchain + '/clang++'
+nm         = xctoolchain + '/nm'
+ar         = xctoolchain + '/ar'
+strip      = xctoolchain + '/strip'
+lipo       = xctoolchain + '/lipo'
+strings    = xctoolchain + '/strings'
+ranlib     = xctoolchain + '/ranlib'
+pkg-config = 'pkg-config'
+
+[built-in options]
+c_args           = ['-arch', arch, '-isysroot', xcplatform, min_version] + silence
+cpp_args         = ['-arch', arch, '-isysroot', xcplatform, min_version, '-stdlib=libc++'] + silence
+objc_args        = ['-arch', arch, '-isysroot', xcplatform, min_version] + silence
+objcpp_args      = ['-arch', arch, '-isysroot', xcplatform, min_version, '-stdlib=libc++'] + silence
+c_link_args      = ['-arch', arch, '-isysroot', xcplatform, min_version]
+cpp_link_args    = ['-arch', arch, '-isysroot', xcplatform, min_version]
+objc_link_args   = ['-arch', arch, '-isysroot', xcplatform, min_version]
+objcpp_link_args = ['-arch', arch, '-isysroot', xcplatform, min_version]
+
+[properties]
+cmake_osx_sysroot = xcplatform
+cross_prefix      = xctoolchain

--- a/cross-files/tvossimulator-arm64.ini
+++ b/cross-files/tvossimulator-arm64.ini
@@ -1,0 +1,41 @@
+[constants]
+arch          = 'arm64'
+platform_name = 'AppleTVSimulator'
+min_version   = '-mtvos-version-min=12.0'
+silence       = ['-DGLES_SILENCE_DEPRECATION', '-DCOREVIDEO_SILENCE_GL_DEPRECATION', '-U_LIBCPP_ENABLE_ASSERTIONS']
+xcode         = '/Applications/Xcode.app'
+xctoolchain   = xcode + '/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin'
+xcplatform    = xcode + '/Contents/Developer/Platforms/' + platform_name + '.platform/Developer/SDKs/' + platform_name + '.sdk'
+
+[host_machine]
+system     = 'darwin'
+cpu_family = 'aarch64'
+cpu        = 'arm64'
+endian     = 'little'
+
+[binaries]
+c          = xctoolchain + '/clang'
+cpp        = xctoolchain + '/clang++'
+objc       = xctoolchain + '/clang'
+objcpp     = xctoolchain + '/clang++'
+nm         = xctoolchain + '/nm'
+ar         = xctoolchain + '/ar'
+strip      = xctoolchain + '/strip'
+lipo       = xctoolchain + '/lipo'
+strings    = xctoolchain + '/strings'
+ranlib     = xctoolchain + '/ranlib'
+pkg-config = 'pkg-config'
+
+[built-in options]
+c_args           = ['-target', 'arm64-apple-tvos-simulator', '-arch', arch, '-isysroot', xcplatform, min_version] + silence
+cpp_args         = ['-target', 'arm64-apple-tvos-simulator', '-arch', arch, '-isysroot', xcplatform, min_version, '-stdlib=libc++'] + silence
+objc_args        = ['-target', 'arm64-apple-tvos-simulator', '-arch', arch, '-isysroot', xcplatform, min_version] + silence
+objcpp_args      = ['-target', 'arm64-apple-tvos-simulator', '-arch', arch, '-isysroot', xcplatform, min_version, '-stdlib=libc++'] + silence
+c_link_args      = ['-target', 'arm64-apple-tvos-simulator', '-arch', arch, '-isysroot', xcplatform, min_version]
+cpp_link_args    = ['-target', 'arm64-apple-tvos-simulator', '-arch', arch, '-isysroot', xcplatform, min_version]
+objc_link_args   = ['-target', 'arm64-apple-tvos-simulator', '-arch', arch, '-isysroot', xcplatform, min_version]
+objcpp_link_args = ['-target', 'arm64-apple-tvos-simulator', '-arch', arch, '-isysroot', xcplatform, min_version]
+
+[properties]
+cmake_osx_sysroot = xcplatform
+cross_prefix      = xctoolchain

--- a/nix/packages/mk-out-frameworks/default.nix
+++ b/nix/packages/mk-out-frameworks/default.nix
@@ -59,7 +59,7 @@ pkgs.stdenvNoCC.mkDerivation {
     if [ ${os} == ${oses.macos} ]; then
       export INFO_PLIST_PATH=${./macos/Info.plist}
       ${buildMacOSScript}
-    elif [ ${os} == ${oses.ios} ] || [ ${os} == ${oses.iossimulator} ]; then
+    elif [ ${os} == ${oses.ios} ] || [ ${os} == ${oses.iossimulator} ] || [ ${os} == ${oses.tvos} ] || [ ${os} == ${oses.tvossimulator} ]; then
       export INFO_PLIST_PATH=${./ios/Info.plist}
       ${buildIOSScript}
     else

--- a/nix/packages/mk-out-xcframeworks/default.nix
+++ b/nix/packages/mk-out-xcframeworks/default.nix
@@ -26,6 +26,11 @@ let
         (callPackage ../mk-out-frameworks/default.nix { os = oses.ios; })
         (callPackage ../mk-out-frameworks/default.nix { os = oses.iossimulator; })
       ]
+    else if os == oses.tvos then
+      [
+        (callPackage ../mk-out-frameworks/default.nix { os = oses.tvos; })
+        (callPackage ../mk-out-frameworks/default.nix { os = oses.tvossimulator; })
+      ]
     else if os == oses.macos then
       [
         (callPackage ../mk-out-frameworks/default.nix { os = oses.macos; })

--- a/nix/packages/mk-pkg-libpng/default.nix
+++ b/nix/packages/mk-pkg-libpng/default.nix
@@ -39,6 +39,10 @@ let
         unzip ${libpngPatch} -d libpng-patch
         rsync -a libpng-patch/libpng-*/ $src/
 
+        cd $src
+        patch -p1 <${../../../patches/libpng-fix-fp-header-on-apple.patch}
+        cd -
+
         cp -r $src $out
       '';
 in

--- a/nix/packages/mk-pkg-libvpx/default.nix
+++ b/nix/packages/mk-pkg-libvpx/default.nix
@@ -35,6 +35,9 @@ let
     if [[ "$sdk" == "iphonesimulator" && "$show_sdk_version" == true ]]; then
       echo ${pkgs.darwin.xcode}/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk
       exit 0
+    elif [[ "$sdk" == "appletvsimulator" && "$show_sdk_version" == true ]]; then
+      echo ${pkgs.darwin.xcode}/Contents/Developer/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator.sdk
+      exit 0
     else
       echo UNIMPLEMETED
       exit 1

--- a/nix/packages/mk-pkg-mbedtls/meson.build
+++ b/nix/packages/mk-pkg-mbedtls/meson.build
@@ -20,6 +20,8 @@ options.add_cmake_defines({
     'USE_STATIC_MBEDTLS_LIBRARY': false,
     'USE_SHARED_MBEDTLS_LIBRARY': true,
     'LINK_WITH_PTHREAD': true,
+    'ENABLE_PROGRAMS': false,
+    'ENABLE_TESTING': false,
 })
 
 mbedtls = cmake.subproject('mbedtls',

--- a/nix/packages/mk-pkg-mpv/default.nix
+++ b/nix/packages/mk-pkg-mpv/default.nix
@@ -48,6 +48,7 @@ let
     cd $src
     patch -p1 <${../../../patches/mpv-fix-missing-objc.patch}
     patch -p1 <${../../../patches/mpv-mix-with-others.patch}
+    patch -p1 <${../../../patches/mpv-subprocess-tvos-stub.patch}
     if [ "${variant}" == "${variants.audio}" ]; then
       patch -p1 <${../../../patches/mpv-remove-libass.patch}
     fi
@@ -249,7 +250,7 @@ pkgs.stdenvNoCC.mkDerivation {
       if [ "${variant}" == "${variants.video}" ]; then
         OPTIONS+=("''${MACOS_VIDEO_OPTIONS[@]}")
       fi
-    elif [ "${os}" == "${oses.ios}" ]; then
+    elif [ "${os}" == "${oses.ios}" ] || [ "${os}" == "${oses.tvos}" ]; then
       OPTIONS+=("''${IOS_OPTIONS[@]}")
       if [ "${variant}" == "${variants.video}" ]; then
         OPTIONS+=("''${IOS_VIDEO_OPTIONS[@]}")

--- a/nix/utils/constants/oses.nix
+++ b/nix/utils/constants/oses.nix
@@ -2,4 +2,6 @@
   macos = "macos";
   ios = "ios";
   iossimulator = "iossimulator";
+  tvos = "tvos";
+  tvossimulator = "tvossimulator";
 }

--- a/nix/utils/targets/libs-frameworks.nix
+++ b/nix/utils/targets/libs-frameworks.nix
@@ -20,6 +20,22 @@ in
     arch = archs.universal;
   }
   {
+    os = oses.tvos;
+    arch = archs.arm64;
+  }
+  {
+    os = oses.tvossimulator;
+    arch = archs.arm64;
+  }
+  {
+    os = oses.tvossimulator;
+    arch = archs.amd64;
+  }
+  {
+    os = oses.tvossimulator;
+    arch = archs.universal;
+  }
+  {
     os = oses.macos;
     arch = archs.arm64;
   }

--- a/nix/utils/targets/pkgs.nix
+++ b/nix/utils/targets/pkgs.nix
@@ -16,6 +16,18 @@ in
     arch = archs.amd64;
   }
   {
+    os = oses.tvos;
+    arch = archs.arm64;
+  }
+  {
+    os = oses.tvossimulator;
+    arch = archs.arm64;
+  }
+  {
+    os = oses.tvossimulator;
+    arch = archs.amd64;
+  }
+  {
     os = oses.macos;
     arch = archs.arm64;
   }

--- a/nix/utils/targets/xcframeworks.nix
+++ b/nix/utils/targets/xcframeworks.nix
@@ -8,6 +8,10 @@ in
     arch = archs.universal;
   }
   {
+    os = oses.tvos;
+    arch = archs.universal;
+  }
+  {
     os = oses.macos;
     arch = archs.universal;
   }

--- a/nix/utils/xctoolchain/xcodebuild.swift
+++ b/nix/utils/xctoolchain/xcodebuild.swift
@@ -145,6 +145,10 @@ func getPlatformAndVariant(usingVtoolFor binaryPath: String, architectures: [Str
       return ("ios", "simulator")
     } else if output.contains("LC_VERSION_MIN_IPHONEOS") && architecture == "arm64" {
       return ("ios", nil)
+    } else if output.contains("TVOSSIMULATOR") {
+      return ("tvos", "simulator")
+    } else if output.contains("platform TVOS") {
+      return ("tvos", nil)
     } else if output.contains("LC_VERSION_MIN_MACOSX") || output.contains("MACOS") {
       return ("macos", nil)
     }

--- a/patches/libpng-fix-fp-header-on-apple.patch
+++ b/patches/libpng-fix-fp-header-on-apple.patch
@@ -1,0 +1,20 @@
+Modern Apple SDKs (iOS, tvOS, macOS) do not expose <fp.h> in the default
+include search path; it only exists inside CoreServices' CarbonCore
+framework on macOS. The existing TARGET_OS_MAC guard triggers on every
+Apple OS (TARGET_OS_MAC is 1 on macOS, iOS, tvOS, watchOS, visionOS),
+which causes the build to fail with "'fp.h' file not found". Force the
+<math.h> path on Darwin, matching what every modern Apple toolchain
+expects.
+
+--- a/pngpriv.h
++++ b/pngpriv.h
+@@ -514,7 +514,8 @@
+ #  include <float.h>
+
+ #  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
+-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
++    defined(THINK_C) || defined(__SC__) || \
++    (defined(TARGET_OS_MAC) && !defined(__APPLE__))
+    /* We need to check that <math.h> hasn't already been included earlier
+     * as it seems it doesn't agree with <fp.h>, yet we should really use
+     * <fp.h> if possible.

--- a/patches/mpv-subprocess-tvos-stub.patch
+++ b/patches/mpv-subprocess-tvos-stub.patch
@@ -1,0 +1,31 @@
+tvOS prohibits fork(), marking it with __TVOS_PROHIBITED. The POSIX
+subprocess implementation is unusable on tvOS; provide a stub that
+reports MP_SUBPROCESS_EUNSUPPORTED instead, matching mpv's declared
+error contract for unavailable subprocess APIs.
+
+--- a/osdep/subprocess-posix.c
++++ b/osdep/subprocess-posix.c
+@@ -31,6 +31,18 @@
+ #include "osdep/io.h"
+ #include "stream/stream.h"
+
++#if defined(__APPLE__)
++#include <TargetConditionals.h>
++#endif
++
++#if defined(TARGET_OS_TV) && TARGET_OS_TV
++void mp_subprocess2(struct mp_subprocess_opts *opts,
++                    struct mp_subprocess_result *res)
++{
++    *res = (struct mp_subprocess_result){0};
++    res->error = MP_SUBPROCESS_EUNSUPPORTED;
++}
++#else
+ extern char **environ;
+
+ #ifdef SIGRTMAX
+@@ -344,3 +356,4 @@ void mp_subprocess2(struct mp_subprocess_opts *opts,
+         res->error = MP_SUBPROCESS_EGENERIC;
+     }
+ }
++#endif /* !TARGET_OS_TV */


### PR DESCRIPTION
  ## Summary                                                                                                                          
                  
  Adds cross-compilation support for **tvOS** (arm64) and **tvOS Simulator** (amd64 + arm64), bringing libmpv-darwin-build in line    
  with the existing iOS / macOS / visionOS targets.
                                                                                                                                      
  ### What's included

  - **Meson cross files** for the three new triplets under `cross-files/`:                                                            
    - `tvos-arm64.ini`
    - `tvossimulator-amd64.ini`                                                                                                       
    - `tvossimulator-arm64.ini`
  - **Nix build wiring** for the new OS in `nix/utils/constants/oses.nix`, plus target/xcframework/frameworks plumbing so `xcodebuild 
  -create-xcframework` picks up the new slices.                                                                                       
  - **Xcode toolchain** (`nix/utils/xctoolchain/xcodebuild.swift`) updated to resolve the AppleTVOS / AppleTVSimulator SDKs.
  - **Patches** for tvOS-specific platform constraints:                                                                               
    - `patches/libpng-fix-fp-header-on-apple.patch` — fixes a floating-point header include that breaks under modern Apple SDKs.      
    - `patches/mpv-subprocess-tvos-stub.patch` — tvOS marks `fork()` as `__TVOS_PROHIBITED`, so the POSIX subprocess implementation is
   replaced with a stub that returns `MP_SUBPROCESS_EUNSUPPORTED`, matching mpv's declared error contract for unavailable subprocess  
  APIs.                                                                                                                               
  - **Per-package tweaks** for `libpng`, `libvpx`, `mbedtls`, and `mpv` to compile cleanly against the tvOS SDK.                      
  - **README** updated with the new targets table rows (min deployment: `12.0`).                                                      
                                                                                                                                      
  ### Minimum deployment target                                                                                                       
                                                                                                                                      
  `tvOS 12.0` for both device and simulator — matches the iOS baseline and keeps OpenGL ES linkable (deprecated but still available). 
  
## Build Artifacts

I built and published tvOS artifacts in my fork here:

https://github.com/bsogulcan/libmpv-darwin-build/releases/tag/v0.6.4

## Verification

Tested successfully on tvOS Simulator.

### tvOS Simulator Proof
<img width="1261" height="802" alt="image" src="https://github.com/user-attachments/assets/1fb9d526-d663-474d-bc49-82dfc6fe944d" />

## Notes

I understand tvOS may currently be outside the scope of the related Flutter package, and this may not be something you want to support or merge right now.