### PR TITLE
refactor: drive build version via make variable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,34 +48,27 @@ jobs:
         id: xcode_path
         run: |
           XCODE_PATH=$(realpath /Applications/Xcode_16.1.0.app)
+
           ${XCODE_PATH}/Contents/Developer/usr/bin/xcodebuild -version
 
           echo "xcode_path=${XCODE_PATH}" >> $GITHUB_OUTPUT
-          echo ${XCODE_PATH}
 
       - name: Build version
         id: version
         run: |
-          case "${GITHUB_REF}" in
-          refs/tags/*)
-            VERSION=${GITHUB_REF#refs/tags/}
-            ;;
-          *)
-            VERSION=develop
-            ;;
-          esac
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
 
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo ${VERSION}
 
       # See ${workspace}/Makefile
       - name: Build
         env:
-          VERSION: ${{ steps.version.outputs.version }}
           XCODE_PATH: ${{ steps.xcode_path.outputs.xcode_path }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          echo \"$VERSION\" > nix/utils/default/version.nix
-          nix develop -c make XCODE_PATH=${XCODE_PATH}
+          nix develop -c make XCODE_PATH=${XCODE_PATH} VERSION=${VERSION}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/.nix/config/version.txt
+++ b/.nix/config/version.txt
@@ -1,0 +1,1 @@
+develop

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@
 # Example: make XCODE_PATH=/Applications/Xcode_16.1.0.app
 XCODE_PATH ?=
 
+# Version string to build. If not set, falls back to .nix/config/version.txt.
+# Example: make VERSION=0.0.1
+VERSION ?=
+
 # Flake output attribute to build. If not set, the default package is built.
 # Example: make TARGET=mk-out-archive-libs-macos-universal-video-default
 TARGET ?=
@@ -11,11 +15,13 @@ TARGET ?=
 all: build
 
 # Build using Nix flakes.
-# After the build, .nix/config/xcode.path is restored to its committed value.
+# After the build, .nix/config/xcode.path and .nix/config/version.txt are
+# restored to their committed values.
 .PHONY: build
 build:
-	trap 'git checkout -- .nix/config/xcode.path' EXIT; \
-	echo '$(XCODE_PATH)' > .nix/config/xcode.path; \
+	trap 'git checkout -- .nix/config/xcode.path .nix/config/version.txt' EXIT; \
+	$(if $(XCODE_PATH),echo '$(XCODE_PATH)' > .nix/config/xcode.path;,) \
+	$(if $(VERSION),echo '$(VERSION)' > .nix/config/version.txt;,) \
 	nix build -v -L \
 		--option sandbox true \
 		--option sandbox-fallback false \

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Heavily inspired by [Homebrew](https://github.com/Homebrew/brew) and
 ## Build
 
 ```shell
-$ echo \"v0.0.1\" > nix/utils/default/version.nix
-$ nix develop -c make
+$ nix develop -c make VERSION=v0.0.1
 $ tree result
 ```
 

--- a/nix/packages/mk-out-all/default.nix
+++ b/nix/packages/mk-out-all/default.nix
@@ -4,7 +4,7 @@
 
 let
   name = "all";
-  version = import ../../utils/default/version.nix;
+  version = import ../../utils/version/default.nix { inherit pkgs; };
 
   pname = import ../../utils/name/output.nix name;
   flavors = import ../../utils/default/flavors.nix;

--- a/nix/packages/mk-out-archive/default.nix
+++ b/nix/packages/mk-out-archive/default.nix
@@ -9,7 +9,7 @@
 
 let
   name = "archive";
-  version = import ../../utils/default/version.nix;
+  version = import ../../utils/version/default.nix { inherit pkgs; };
 
   callPackage = pkgs.lib.callPackageWith {
     inherit

--- a/nix/packages/mk-out-frameworks/default.nix
+++ b/nix/packages/mk-out-frameworks/default.nix
@@ -8,7 +8,7 @@
 
 let
   name = "frameworks";
-  version = import ../../utils/default/version.nix;
+  version = import ../../utils/version/default.nix { inherit pkgs; };
   callPackage = pkgs.lib.callPackageWith {
     inherit
       pkgs

--- a/nix/packages/mk-out-libs/default.nix
+++ b/nix/packages/mk-out-libs/default.nix
@@ -8,7 +8,7 @@
 
 let
   name = "libs";
-  version = import ../../utils/default/version.nix;
+  version = import ../../utils/version/default.nix { inherit pkgs; };
 
   archs = import ../../utils/constants/archs.nix;
   flavors = import ../../utils/constants/flavors.nix;

--- a/nix/packages/mk-out-xcframeworks/default.nix
+++ b/nix/packages/mk-out-xcframeworks/default.nix
@@ -8,7 +8,7 @@
 
 let
   name = "xcframeworks";
-  version = import ../../utils/default/version.nix;
+  version = import ../../utils/version/default.nix { inherit pkgs; };
   pname = import ../../utils/name/output.nix name;
   oses = import ../../utils/constants/oses.nix;
   callPackage = pkgs.lib.callPackageWith {

--- a/nix/utils/default/version.nix
+++ b/nix/utils/default/version.nix
@@ -1,1 +1,0 @@
-"develop"

--- a/nix/utils/version/default.nix
+++ b/nix/utils/version/default.nix
@@ -1,0 +1,5 @@
+{
+  pkgs ? import ../default/pkgs.nix,
+}:
+
+pkgs.lib.trim (builtins.readFile ../../../.nix/config/version.txt)


### PR DESCRIPTION
Instead of manually writing to nix/utils/default/version.nix before building, the version is now read from .nix/config/version.txt, which can be overridden at build time via `make VERSION=x.y.z`. The CI and Makefile are updated accordingly.