### PR TITLE
Fix SwiftPM artifact permissions

### DIFF
--- a/nix/packages/mk-out-archive/default.nix
+++ b/nix/packages/mk-out-archive/default.nix
@@ -52,7 +52,7 @@ pkgs.stdenvNoCC.mkDerivation {
   ''
   + pkgs.lib.optionalString (format == formats.xcframeworks) ''
     (
-      cd $src
+      cd ${archiveBaseName}
       for XCFRAMEWORK in *.xcframework; do
         FRAMEWORK_NAME=$(basename $XCFRAMEWORK .xcframework)
         zip -Xyr $build/${archiveBaseName}_$FRAMEWORK_NAME.zip $XCFRAMEWORK


### PR DESCRIPTION
This fixes the SwiftPM zip packaging for xcframework artifacts.

Previously the zip files were created directly from `$src`, which points to the Nix store. As a result, the extracted `.xcframework` directories kept read-only permissions. Xcode/SwiftPM then failed to clean or re-extract binary artifacts from DerivedData with `NSCocoaErrorDomain Code=513`.

This change creates the `.zip` files from the writable copied archive directory instead of `$src`, while keeping the existing `.tar.gz` output unchanged.

Tested with `media_kit_test`, where the current v0.7.0 artifacts fail during SwiftPM package resolution because the extracted binary artifacts are read-only.

Needed for media-kit/media-kit#1412.
